### PR TITLE
Standardize README: badges, Conda install, License section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # basejump
 
-[![Install with Bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](http://bioconda.github.io/recipes/r-basejump/README.html) ![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)
+[![Install with Bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](https://bioconda.github.io/recipes/r-basejump/README.html) ![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)
 
 Base functions for bioinformatics and [R][] package development.
 
@@ -37,3 +37,7 @@ R
 [bioconda]: https://bioconda.github.io/
 [conda]: https://docs.conda.io/
 [r]: https://www.r-project.org/
+
+## License
+
+Apache-2.0 — Copyright 2016 Acid Genomics LLC — see [LICENSE.md](LICENSE.md).


### PR DESCRIPTION
- Fix bioconda badge link: http → https
- Add License section (Apache-2.0, copyright 2016)